### PR TITLE
Replace Go Meta Linter with golangci-int

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Table of Contents
 * [go/ast](https://golang.org/pkg/go/ast/) [OSS] - Package ast declares the types used to represent syntax trees for Go packages.
 * [go-staticcheck](https://github.com/dominikh/go-staticcheck) [OSS] - go vet on steroids, similar to ReSharper for C#
 * [gocyclo](https://github.com/fzipp/gocyclo) [OSS] - Calculate cyclomatic complexities of functions in Go source code
-* [Go Meta Linter](https://github.com/alecthomas/gometalinter) [OSS] - Concurrently run Go lint tools and normalise their output
+* [golangci-lint](https://github.com/golangci/golangci-lint) [OSS] - Concurrently run Go lint tools and normalize their output
 * [go vet](https://golang.org/cmd/vet/) [OSS] - Examines Go source code and reports suspicious constructs
 * [ineffassign](https://github.com/gordonklaus/ineffassign) - Detect ineffectual assignments in Go code
 * [safesql](https://github.com/stripe/safesql) [OSS] - Static analysis tool for Golang that protects against SQL injections


### PR DESCRIPTION
The Go Meta Linter repo says that it is deprecated in favor of golangci-lint, and that tool is much more popular and capable as well.